### PR TITLE
Remove chown of GitHub runner home directory and execute ORT image with correct user and group id

### DIFF
--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -54,8 +54,7 @@ runs:
       shell: bash
       run: |
         docker pull ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }}
-        docker run ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} --version
-        
+
     - name: Initialize ORT workspace
       shell: bash
       run: |

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -55,6 +55,16 @@ runs:
       run: |
         docker pull ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }}
         docker run ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} --version
+        
+    - name: Initialize ORT workspace
+      shell: bash
+      run: |
+        mkdir -p $HOME/.cache/scancode-tk/; chmod -R aug+w ${HOME}/.cache/ || :
+        mkdir -p $HOME/.config/jgit/; chmod -R aug+w ${HOME}/.config/ || :
+        mkdir -p $HOME/$ORT_HOME_PATH/{cache,config,ort-results,scanner/archive/,scanner/provenance/}; chmod -R aug+w ${HOME}/$ORT_HOME_PATH/ || :
+        mkdir -p $HOME/.gradle/; chmod -R aug+w ${HOME}/.gradle/ || :
+        mkdir -p $HOME/.rustup/{cache,download,tmp}; chmod -R aug+w ${HOME}/.rustup/ || :
+        mkdir -p $HOME/go/; chmod -R aug+w ${HOME}/go/ || :
 
     # https://github.com/oss-review-toolkit/ort#analyzer
     - name: ORT Analyzer

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -72,6 +72,7 @@ runs:
       shell: bash
       run: |
         docker run \
+          --mount type=bind,source=$HOME,target=/home/ort
           -v ${{ inputs.project-dir }}:/project \
           -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -56,10 +56,6 @@ runs:
         docker pull ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }}
         docker run ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} --version
 
-    - name: Set ownership of project directory
-      shell: bash
-      run: sudo chown -R 1000:1000 ${{ inputs.project-dir }}
-
     # https://github.com/oss-review-toolkit/ort#analyzer
     - name: ORT Analyzer
       continue-on-error: true
@@ -67,6 +63,7 @@ runs:
       run: |
         docker run \
           -v ${{ inputs.project-dir }}:/project \
+          -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \
           -P ort.analyzer.allowDynamicVersions=${{ inputs.allow-dynamic-versions }} \
           --debug analyze \
@@ -76,5 +73,5 @@ runs:
     # Archive ORT YAML result
     - uses: actions/upload-artifact@v3
       with:
-        name: OSS Review Toolkit result (YAML)
+        name: ort-analyzer-result
         path: ort/analyzer-result.yml

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -39,14 +39,14 @@ runs:
   using: composite
   steps:
     # Configure AWS credentials
-    - uses: aws-actions/configure-aws-credentials@v1
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.ort-aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.ort-aws-secret-access-key }}
         aws-region: eu-central-1
 
     # Login to ORT Amazon ECR
-    - uses: aws-actions/amazon-ecr-login@v1
+    - uses: aws-actions/amazon-ecr-login@v2
       with:
         mask-password: true
 
@@ -61,7 +61,7 @@ runs:
       run: |
         mkdir -p $HOME/.cache/scancode-tk/; chmod -R aug+w ${HOME}/.cache/ || :
         mkdir -p $HOME/.config/jgit/; chmod -R aug+w ${HOME}/.config/ || :
-        mkdir -p $HOME/$ORT_HOME_PATH/{cache,config,ort-results,scanner/archive/,scanner/provenance/}; chmod -R aug+w ${HOME}/$ORT_HOME_PATH/ || :
+        mkdir -p $HOME/.ort/{cache,config,ort-results,scanner/archive/,scanner/provenance/}; chmod -R aug+w ${HOME}/.ort/ || :
         mkdir -p $HOME/.gradle/; chmod -R aug+w ${HOME}/.gradle/ || :
         mkdir -p $HOME/.rustup/{cache,download,tmp}; chmod -R aug+w ${HOME}/.rustup/ || :
         mkdir -p $HOME/go/; chmod -R aug+w ${HOME}/go/ || :
@@ -77,12 +77,12 @@ runs:
           -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \
           -P ort.analyzer.allowDynamicVersions=${{ inputs.allow-dynamic-versions }} \
-          --debug analyze \
+          analyze \
           --input-dir /project/ \
           --output-dir /project/ort/
 
     # Archive ORT YAML result
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ort-analyzer-result
         path: ort/analyzer-result.yml

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -64,6 +64,10 @@ runs:
         mkdir -p $HOME/.gradle/; chmod -R aug+w ${HOME}/.gradle/ || :
         mkdir -p $HOME/.rustup/{cache,download,tmp}; chmod -R aug+w ${HOME}/.rustup/ || :
         mkdir -p $HOME/go/; chmod -R aug+w ${HOME}/go/ || :
+        container_id=$(docker create ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }}) || :
+        docker cp $container_id:/home/ort/curations/ $HOME/curations || :
+        docker cp $container_id:/home/ort/.ort/config/config.yml $HOME/.ort/config/config.yml || :
+        docker rm $container_id || :
 
     # https://github.com/oss-review-toolkit/ort#analyzer
     - name: ORT Analyzer

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -72,7 +72,7 @@ runs:
       shell: bash
       run: |
         docker run \
-          --mount type=bind,source=$HOME,target=/home/ort
+          --mount type=bind,source=$HOME,target=/home/ort \
           -v ${{ inputs.project-dir }}:/project \
           -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \


### PR DESCRIPTION
## 📑 Description
This PR further optimizes the shared ORT GitHub action:
- Update of dependencies / actions
- `chown` of the complete runner's home directory has been removed and ORT container is nowexecuted with correct user and group id. This allows the analyzer result to be processed in following steps by the GitHub runner (e.g. zipping the result file).
- Removed unneeded debug output

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
