### PR TITLE
add optional input to limit ORT analyzer package managers

### DIFF
--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -39,14 +39,14 @@ inputs:
       Continue the workflow even if the ORT analyzer fails. Set to 'false' to fail on errors.
     required: false
     default: 'true'
-enabled-package-managers:
-  description: >
-    Optional. Comma-separated list of ORT analyzer package managers.
-    Allowed values:
-    Bazel, Bower, Bundler, Cargo, Carthage, CocoaPods, Composer, Conan, GoMod, Gradle, GradleInspector, Maven, NPM, NuGet, PIP, Pipenv, PNPM,
-    Poetry, Pub, SBT, SpdxDocumentFile, Stack, SwiftPM, Tycho, Unmanaged, Yarn, Yarn2.
-  required: false
-
+  enabled-package-managers:
+    description: >
+      Optional. Comma-separated list of ORT analyzer package managers.
+      Allowed values:
+      Bazel, Bower, Bundler, Cargo, Carthage, CocoaPods, Composer, Conan, GoMod, Gradle, GradleInspector, Maven, NPM, NuGet, PIP, Pipenv, PNPM,
+      Poetry, Pub, SBT, SpdxDocumentFile, Stack, SwiftPM, Tycho, Unmanaged, Yarn, Yarn2.
+    required: false
+    
 runs:
   using: composite
   steps:
@@ -105,6 +105,7 @@ runs:
       with:
         name: ort-analyzer-result
         path: ${{ inputs.project-dir }}/ort/analyzer-result.yml
+
 
 
 

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -39,11 +39,13 @@ inputs:
       Continue the workflow even if the ORT analyzer fails. Set to 'false' to fail on errors.
     required: false
     default: 'true'
-  enabled-package-managers:
-    description: >
-      Optional. Comma-separated list of ORT analyzer package managers
-      (e.g. PNPM, NPM, Maven). If not set, all package managers are enabled.
-    required: false
+enabled-package-managers:
+  description: >
+    Optional. Comma-separated list of ORT analyzer package managers.
+    Allowed values:
+    Bazel, Bower, Bundler, Cargo, Carthage, CocoaPods, Composer, Conan, GoMod, Gradle, GradleInspector, Maven, NPM, NuGet, PIP, Pipenv, PNPM,
+    Poetry, Pub, SBT, SpdxDocumentFile, Stack, SwiftPM, Tycho, Unmanaged, Yarn, Yarn2.
+  required: false
 
 runs:
   using: composite
@@ -103,6 +105,7 @@ runs:
       with:
         name: ort-analyzer-result
         path: ${{ inputs.project-dir }}/ort/analyzer-result.yml
+
 
 
 

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -93,7 +93,7 @@ runs:
           -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \
           -P ort.analyzer.allowDynamicVersions=${{ inputs.allow-dynamic-versions }} \
-          ${{ inputs.enabled-package-managers && format('-P ort.analyzer.enabledPackageManagers=%s', inputs.enabled-package-managers) || '' }} \
+          ${{ inputs.enabled-package-managers && format('-P ort.analyzer.enabledPackageManagers={0}', inputs.enabled-package-managers) || '' }} \
           analyze \
           --input-dir /project/ \
           --output-dir /project/ort/
@@ -103,5 +103,6 @@ runs:
       with:
         name: ort-analyzer-result
         path: ${{ inputs.project-dir }}/ort/analyzer-result.yml
+
 
 

--- a/workflows/ort-analyze/action.yml
+++ b/workflows/ort-analyze/action.yml
@@ -39,6 +39,11 @@ inputs:
       Continue the workflow even if the ORT analyzer fails. Set to 'false' to fail on errors.
     required: false
     default: 'true'
+  enabled-package-managers:
+    description: >
+      Optional. Comma-separated list of ORT analyzer package managers
+      (e.g. PNPM, NPM, Maven). If not set, all package managers are enabled.
+    required: false
 
 runs:
   using: composite
@@ -88,6 +93,7 @@ runs:
           -u $(id -u):$(id -g) \
           ${{ inputs.container-registry }}/${{ inputs.container-repository }}:${{ inputs.container-image-tag }} \
           -P ort.analyzer.allowDynamicVersions=${{ inputs.allow-dynamic-versions }} \
+          ${{ inputs.enabled-package-managers && format('-P ort.analyzer.enabledPackageManagers=%s', inputs.enabled-package-managers) || '' }} \
           analyze \
           --input-dir /project/ \
           --output-dir /project/ort/
@@ -97,4 +103,5 @@ runs:
       with:
         name: ort-analyzer-result
         path: ${{ inputs.project-dir }}/ort/analyzer-result.yml
+
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #XPFR019-3193

## 📑 Description
Adds an optional input to restrict ORT analyzer package managers while preserving the default behavior of enabling all package managers.

## ✅ Checks
- [x] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
